### PR TITLE
Bug fixed on copy url

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "react-scripts": "3.0.1"
   },
   "dependencies": {
+    "copy-to-clipboard": "^3.3.1",
     "formik": "^1.5.8",
     "i18next": "^19.0.3",
     "i18next-browser-languagedetector": "^4.0.1",
     "react": "^16.8.6",
-    "react-copy-to-clipboard": "^5.0.2",
     "react-date-picker": "^7.7.0",
     "react-dom": "^16.8.6",
     "react-i18next": "^11.3.0"

--- a/src/DatastoreSearchSql.js
+++ b/src/DatastoreSearchSql.js
@@ -3,7 +3,7 @@ import "./i18n/i18n"
 import React, { useState } from 'react';
 import {Formik, Form, FieldArray, Field} from 'formik'
 import DatePicker from 'react-date-picker'
-import copy from 'copy-to-clipboard';
+import copy from 'copy-to-clipboard'
 import {useTranslation} from "react-i18next"
 
 
@@ -75,7 +75,9 @@ function DatastoreSearchSql(props) {
       props.action(resource)
     } 
 
-    copy(datastoreUrl.replace('COUNT(*) OVER () AS _count, ', ''))
+    if (action === 'COPY') {
+      copy(datastoreUrl.replace('COUNT(*) OVER () AS _count, ', ''))
+    } 
 
     // Update download links
     let downloadCsvApiUri, downloadJsonApiUri, downloadExcelApiUri
@@ -208,7 +210,7 @@ function DatastoreSearchSql(props) {
                   <button type="submit" className="btn btn-primary reset-button" onClick={handleReset}>{t('Reset')}</button>
                   <button type="button" className="btn btn-primary copy-button" onClick={ async()=> {
                     await setFieldValue('ACTION', 'COPY')
-                    handleSubmit();
+                    handleSubmit()
                     setCopied(true)
                   }}>{copied ? "Copied" : "Copy API URI"}</button>
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,7 +2408,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-copy-to-clipboard@^3:
+copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
@@ -7170,7 +7170,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -7322,14 +7322,6 @@ react-calendar@^2.18.0:
     merge-class-names "^1.1.1"
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
-
-react-copy-to-clipboard@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz#d82a437e081e68dfca3761fbd57dbf2abdda1316"
-  integrity sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==
-  dependencies:
-    copy-to-clipboard "^3"
-    prop-types "^15.5.8"
 
 react-cosmos-config@^4.8.0-alpha.0:
   version "4.8.2"


### PR DESCRIPTION
**BUG:**  Before `cleanedDatastoreUrl` state only updated after the form submits. To generate a new URL user needs to click the submit button first and then he/she able to copy the latest filter. 

**Fixes**:
- Copy after prepared URL, which means it will execute `handleSubmit()`   function every time when user clicks the copy button.
-  `handleSubmit()`  will look for the action type. Dispatch the data explorer props action if only the action type is `SUBMIT`.
-   Removed `react-copy-to-clipboard` package and added `copy-to-clipboard`. 
Did little hacky approach while passing   `COPY, SUBMIT` action type on the `Formik` submit action. Couldn't find another way. 
