### PR TITLE
add pt_BR l10n

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -4,6 +4,7 @@ import { initReactI18next } from "react-i18next";
 import en from './locales/en/translation.json'
 import da from './locales/da/translation.json'
 import fr from './locales/fr/translation.json'
+import pt_BR from './locales/pt_BR/translation.json'
 
 i18n
   .use(LanguageDetector)
@@ -27,7 +28,8 @@ i18n
     resources: {
       en: {translation: en},
       da: {translation: da},
-      fr: {translation: fr}
+      fr: {translation: fr},
+      pt_BR: {translation: pt_BR}
     },
 
     react: {

--- a/src/i18n/locales/pt_BR/translation.json
+++ b/src/i18n/locales/pt_BR/translation.json
@@ -1,0 +1,5 @@
+{
+  "Add a rule": "Adicionar uma regra",
+  "Submit": "Enviar",
+  "Reset": "Reiniciar"
+}


### PR DESCRIPTION
This PR adds Brazilian Portuguese localization to the package.

The language code used is `pt_BR`, to be consistent with the POSIX standard for country variants. To be consistent, PR datopian/datapackage-views-js#60 should be approved too.